### PR TITLE
feat: GetCurrentRef

### DIFF
--- a/get_current_ref.go
+++ b/get_current_ref.go
@@ -1,0 +1,26 @@
+package integrations
+
+import "os"
+
+// GetCurrentRef will return the Reference provided by gitlab, github or drone.
+func GetCurrentRef() string {
+	gitlabRef := os.Getenv("CI_COMMIT_REF_NAME")
+
+	if gitlabRef != "" {
+		return gitlabRef
+	}
+
+	githubRef := os.Getenv("GITHUB_REF")
+
+	if githubRef != "" {
+		return githubRef
+	}
+
+	droneRef := os.Getenv("DRONE_COMMIT_REF")
+
+	if droneRef != "" {
+		return droneRef
+	}
+
+	return ""
+}

--- a/get_current_ref_test.go
+++ b/get_current_ref_test.go
@@ -1,0 +1,42 @@
+package integrations
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetCurrentRef(t *testing.T) {
+	// Github action specific environment variable
+	os.Setenv("GITHUB_REF", "github-develop")
+
+	actionCompareBranch := GetCurrentRef()
+
+	assert.Equal(t, "github-develop", actionCompareBranch)
+
+	os.Setenv("GITHUB_REF", "")
+
+	// Gitlab specific environment variable
+	os.Setenv("CI_COMMIT_REF_NAME", "gitlab-develop")
+
+	gitlabCompareBranch := GetCurrentRef()
+
+	assert.Equal(t, "gitlab-develop", gitlabCompareBranch)
+
+	os.Setenv("CI_COMMIT_REF_NAME", "")
+
+	// Drone specific environment variable
+	os.Setenv("DRONE_COMMIT_REF", "drone-develop")
+
+	droneCompareBranch := GetCurrentRef()
+
+	assert.Equal(t, "drone-develop", droneCompareBranch)
+
+	os.Setenv("DRONE_COMMIT_REF", "")
+
+	// Should default to empty if no conditions are satisfied
+	defaultMaster := GetCurrentRef()
+
+	assert.Equal(t, "", defaultMaster)
+}


### PR DESCRIPTION
GetCurrentRef allows user to get the reference the commit is on. This would be a branch or a tag. Returns empty if the CI is not supported.